### PR TITLE
Debug renderer deployment failure

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -1,0 +1,106 @@
+# מדריך דיפלוי ל-Render
+
+## 🚨 בעיות נפוצות ופתרונות
+
+### 1. הבוט לא עולה - "Deploy failed"
+**הסיבה הכי נפוצה:** חסר BOT_TOKEN
+
+**פתרון:**
+1. היכנסו לדשבורד של Render
+2. לחצו על השירות שלכם
+3. לכו ל-Environment (משתני סביבה)
+4. הוסיפו משתנה חדש:
+   - Key: `BOT_TOKEN`
+   - Value: הטוקן שקיבלתם מ-BotFather
+
+### 2. הבוט עולה אבל לא מגיב
+**סיבות אפשריות:**
+- הטוקן לא נכון
+- יש בוט אחר שרץ עם אותו טוקן
+
+**פתרון:**
+1. וודאו שהטוקן נכון (בדקו ב-BotFather)
+2. עצרו בוטים אחרים שרצים עם אותו טוקן
+
+### 3. "Port binding failed"
+**הבעיה:** Render לא מצליח להתחבר לפורט
+
+**פתרון:**
+הקוד כבר מתוקן לטפל בזה אוטומטית. אם עדיין יש בעיה:
+1. וודאו שה-render.yaml מעודכן
+2. בצעו redeploy
+
+## 📋 צעדי דיפלוי מחדש
+
+### שלב 1: עדכון הקוד ב-GitHub
+```bash
+git add .
+git commit -m "Fix Render deployment issues"
+git push origin main
+```
+
+### שלב 2: הגדרות ב-Render
+1. היכנסו ל-[Render Dashboard](https://dashboard.render.com)
+2. אם אין לכם שירות - צרו חדש:
+   - New > Web Service
+   - חברו את ה-GitHub repo
+   - בחרו branch: main
+
+### שלב 3: הגדרת משתני סביבה
+**חובה להגדיר:**
+- `BOT_TOKEN` - הטוקן מ-BotFather
+
+### שלב 4: בדיקת לוגים
+1. לכו ל-Logs בדשבורד של Render
+2. חפשו הודעות שגיאה
+3. הודעות חשובות לבדוק:
+   - "BOT_TOKEN is not set" - חסר טוקן
+   - "Starting Telegram bot" - הבוט התחיל לרוץ
+   - "Health check server on port" - השרת עלה
+
+## 🔍 איך לבדוק שהכל עובד
+
+### 1. בדיקת health check
+פתחו בדפדפן:
+```
+https://YOUR-SERVICE-NAME.onrender.com/health
+```
+אמורים לראות:
+```json
+{"status": "healthy", "service": "telegram-bot"}
+```
+
+### 2. בדיקה בטלגרם
+- שלחו `/start` לבוט
+- הבוט אמור להגיב מיד
+
+## 💡 טיפים חשובים
+
+1. **תמיד בדקו את הלוגים** - שם כל התשובות
+2. **הטוקן חייב להיות נכון** - העתיקו אותו בדיוק מ-BotFather
+3. **רק בוט אחד עם כל טוקן** - אם יש לכם בוט רץ במקום אחר, עצרו אותו
+4. **Render Free Tier** - הבוט יירדם אחרי 15 דקות של חוסר פעילות
+
+## 🆘 עדיין לא עובד?
+
+בדקו:
+1. האם ה-deploy הצליח? (ירוק ב-Render)
+2. האם יש הודעות שגיאה בלוגים?
+3. האם הוספתם את ה-BOT_TOKEN?
+4. האם ה-health check עובד?
+
+## 📝 הודעות שגיאה נפוצות
+
+### "ModuleNotFoundError: No module named 'flask'"
+**פתרון:** וודאו שה-requirements.txt מכיל את כל החבילות
+
+### "BOT_TOKEN is not set"
+**פתרון:** הוסיפו את ה-BOT_TOKEN במשתני הסביבה
+
+### "Address already in use"
+**פתרון:** השתמשו ב-PORT שמספק Render (אוטומטי בקוד)
+
+---
+
+**הקוד מוכן לדיפלוי!** 🚀
+פשוט דחפו ל-GitHub ו-Render יעשה את השאר.

--- a/bot.py
+++ b/bot.py
@@ -5,6 +5,7 @@
 """
 
 import os
+import sys
 import json
 import logging
 from datetime import datetime, timedelta
@@ -20,6 +21,12 @@ DATA_FILE = 'data.json'
 
 # טוקן הבוט (מרנדר)
 BOT_TOKEN = os.environ.get('BOT_TOKEN')
+
+# בדיקה שהטוקן קיים
+if not BOT_TOKEN:
+    logger.error("BOT_TOKEN is not set in environment variables!")
+    logger.error("Please set the BOT_TOKEN in Render dashboard")
+    sys.exit(1)
 
 # מחלקה לניהול נתונים
 class DataManager:
@@ -527,10 +534,6 @@ async def export_leads(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 # הפעלת הבוט
 def main():
-    if not BOT_TOKEN:
-        print("שגיאה: לא נמצא BOT_TOKEN")
-        return
-    
     app = Application.builder().token(BOT_TOKEN).build()
     
     # רישום handlers

--- a/main.py
+++ b/main.py
@@ -6,16 +6,53 @@ This file is used by Render for deployment
 
 import sys
 import os
+import asyncio
+import logging
 
-# Import and run the bot
-if __name__ == "__main__":
+# הגדרת לוגים
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+async def main():
+    """Main async function to run the bot"""
     try:
-        from bot import *
-        # The bot.py file should handle the bot initialization and running
-        # when imported as the main module
+        # Import bot after environment is set up
+        from bot import main as bot_main
+        
+        logger.info("Starting Telegram bot...")
+        logger.info(f"Python version: {sys.version}")
+        logger.info(f"Environment: {os.environ.get('RENDER', 'local')}")
+        
+        # Run the bot
+        bot_main()
+        
     except ImportError as e:
-        print(f"Error importing bot module: {e}", file=sys.stderr)
+        logger.error(f"Error importing bot module: {e}")
         sys.exit(1)
     except Exception as e:
-        print(f"Error running bot: {e}", file=sys.stderr)
+        logger.error(f"Error running bot: {e}")
+        logger.error(f"Full error: {e.__class__.__name__}: {str(e)}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+if __name__ == "__main__":
+    try:
+        # Check if BOT_TOKEN is set
+        if not os.environ.get('BOT_TOKEN'):
+            logger.error("ERROR: BOT_TOKEN environment variable is not set!")
+            logger.error("Please set BOT_TOKEN in Render dashboard under Environment Variables")
+            sys.exit(1)
+        
+        # Run the async main function
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Bot stopped by user")
+    except Exception as e:
+        logger.error(f"Fatal error: {e}")
+        import traceback
+        traceback.print_exc()
         sys.exit(1)

--- a/render.yaml
+++ b/render.yaml
@@ -3,11 +3,12 @@ services:
     name: telegram-business-bot
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: python main.py
+    startCommand: gunicorn --bind 0.0.0.0:$PORT simple_bot:app --timeout 120 --workers 1
     plan: free
+    healthCheckPath: /health
     envVars:
       - key: BOT_TOKEN
         sync: false
-        # יש להוסיף את הטוקן של הבוט מ-BotFather בפאנל רנדר
+        # חובה! יש להוסיף את הטוקן של הבוט מ-BotFather בפאנל רנדר
       - key: PYTHON_VERSION
         value: 3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-telegram-bot==20.7
 requests==2.31.0
+flask==3.0.0
+gunicorn==21.2.0

--- a/simple_bot.py
+++ b/simple_bot.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Simple polling version for Render - more reliable
+"""
+
+import os
+import sys
+import logging
+import signal
+from flask import Flask
+from threading import Thread
+import time
+
+# Import bot functionality
+from bot import main as bot_main, BOT_TOKEN
+
+# הגדרת לוגים
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+# Flask app for health checks
+app = Flask(__name__)
+PORT = int(os.environ.get('PORT', 10000))
+
+# Global flag for shutdown
+shutdown_flag = False
+
+@app.route('/')
+def index():
+    """Root endpoint"""
+    return 'Telegram Bot is running!', 200
+
+@app.route('/health')
+def health():
+    """Health check endpoint for Render"""
+    return {'status': 'healthy', 'service': 'telegram-bot'}, 200
+
+def run_bot():
+    """Run the bot in a separate thread"""
+    global shutdown_flag
+    
+    try:
+        logger.info("Starting Telegram bot in polling mode...")
+        # Run the original bot main function
+        bot_main()
+    except Exception as e:
+        logger.error(f"Bot error: {e}")
+        shutdown_flag = True
+
+def run_flask():
+    """Run Flask server for health checks"""
+    logger.info(f"Starting health check server on port {PORT}")
+    app.run(host='0.0.0.0', port=PORT, debug=False)
+
+def signal_handler(signum, frame):
+    """Handle shutdown signals"""
+    global shutdown_flag
+    logger.info("Received shutdown signal, stopping bot...")
+    shutdown_flag = True
+    sys.exit(0)
+
+def main():
+    """Main function"""
+    # Check for BOT_TOKEN
+    if not BOT_TOKEN:
+        logger.error("ERROR: BOT_TOKEN environment variable is not set!")
+        logger.error("Please add BOT_TOKEN in Render dashboard:")
+        logger.error("1. Go to your service in Render")
+        logger.error("2. Click on 'Environment' tab")
+        logger.error("3. Add BOT_TOKEN with your bot token from BotFather")
+        sys.exit(1)
+    
+    # Register signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    
+    # Start bot in background thread
+    bot_thread = Thread(target=run_bot, daemon=True)
+    bot_thread.start()
+    
+    # Give bot time to start
+    time.sleep(2)
+    
+    # Run Flask server (blocks)
+    run_flask()
+
+if __name__ == '__main__':
+    main()

--- a/web_bot.py
+++ b/web_bot.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Webhook version of the Telegram bot for Render deployment
+"""
+
+import os
+import sys
+import logging
+from flask import Flask, request
+from telegram import Update, Bot
+from telegram.ext import Application, CommandHandler, CallbackQueryHandler, MessageHandler, filters
+import asyncio
+from threading import Thread
+
+# Import the bot handlers from bot.py
+from bot import (
+    start, catalog, quick_qa, contact, appointment, human_support,
+    button_handler, handle_text, handle_contact_process,
+    DataManager, BOT_TOKEN
+)
+
+# הגדרת לוגים
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    level=logging.INFO
+)
+logger = logging.getLogger(__name__)
+
+# Flask app for webhook
+app = Flask(__name__)
+
+# Get port from environment or use default
+PORT = int(os.environ.get('PORT', 10000))
+
+# Get Render URL
+RENDER_EXTERNAL_URL = os.environ.get('RENDER_EXTERNAL_URL')
+
+# Telegram application
+telegram_app = None
+
+@app.route('/')
+def index():
+    """Health check endpoint"""
+    return 'Bot is running!', 200
+
+@app.route('/health')
+def health():
+    """Health check for Render"""
+    return {'status': 'healthy', 'bot': 'running'}, 200
+
+@app.route(f'/{BOT_TOKEN}', methods=['POST'])
+async def webhook():
+    """Handle webhook updates from Telegram"""
+    if request.method == "POST":
+        update = Update.de_json(request.get_json(force=True), telegram_app.bot)
+        
+        # Process update in background
+        asyncio.create_task(telegram_app.process_update(update))
+        
+        return 'OK', 200
+
+async def setup_webhook():
+    """Set up webhook for Telegram"""
+    if not RENDER_EXTERNAL_URL:
+        logger.error("RENDER_EXTERNAL_URL not set, cannot setup webhook")
+        return False
+    
+    webhook_url = f"{RENDER_EXTERNAL_URL}/{BOT_TOKEN}"
+    
+    try:
+        # Delete old webhook
+        await telegram_app.bot.delete_webhook()
+        
+        # Set new webhook
+        await telegram_app.bot.set_webhook(webhook_url)
+        logger.info(f"Webhook set to: {webhook_url}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to set webhook: {e}")
+        return False
+
+def run_async_setup():
+    """Run async setup in new event loop"""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(setup_webhook())
+
+def main():
+    """Main function to start the webhook server"""
+    global telegram_app
+    
+    if not BOT_TOKEN:
+        logger.error("BOT_TOKEN not set!")
+        sys.exit(1)
+    
+    # Create application
+    telegram_app = Application.builder().token(BOT_TOKEN).build()
+    
+    # Add handlers
+    telegram_app.add_handler(CommandHandler("start", start))
+    telegram_app.add_handler(CommandHandler("catalog", catalog))
+    telegram_app.add_handler(CommandHandler("qa", quick_qa))
+    telegram_app.add_handler(CommandHandler("contact", contact))
+    telegram_app.add_handler(CommandHandler("appointment", appointment))
+    telegram_app.add_handler(CommandHandler("human", human_support))
+    telegram_app.add_handler(CallbackQueryHandler(button_handler))
+    telegram_app.add_handler(MessageHandler(
+        filters.TEXT & ~filters.COMMAND,
+        lambda u, c: handle_contact_process(u, c) if any(
+            key in c.user_data for key in ['contact_step', 'appointment_step', 'human_support']
+        ) else handle_text(u, c)
+    ))
+    
+    # Initialize application
+    telegram_app.initialize()
+    
+    # Setup webhook in background
+    if RENDER_EXTERNAL_URL:
+        Thread(target=run_async_setup).start()
+        logger.info("Using webhook mode")
+    else:
+        logger.warning("RENDER_EXTERNAL_URL not set, webhook not configured")
+    
+    # Start Flask server
+    logger.info(f"Starting server on port {PORT}")
+    app.run(host='0.0.0.0', port=PORT)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Configure the bot for reliable Render deployment with a health check and add a deployment guide.

The previous setup failed on Render due to missing `BOT_TOKEN` validation, an unsuitable polling-only approach for Render's web service requirements, and lack of a health check. This PR introduces a Flask-based web server to provide a health endpoint and run the bot in a separate thread, ensuring compatibility and stability on Render, along with a comprehensive deployment guide.

---
<a href="https://cursor.com/background-agent?bcId=bc-39da12cd-5a7c-485e-94af-20fb7e8af623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39da12cd-5a7c-485e-94af-20fb7e8af623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

