### PR TITLE
Fix telegram bot updater attribute error

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,8 +26,8 @@ async def main():
         logger.info(f"Python version: {sys.version}")
         logger.info(f"Environment: {os.environ.get('RENDER', 'local')}")
         
-        # Run the bot
-        bot_main()
+        # Run the bot (it's now async)
+        await bot_main()
         
     except ImportError as e:
         logger.error(f"Error importing bot module: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot==20.7
+python-telegram-bot==21.7
 requests==2.31.0
 flask==3.0.0
 gunicorn==21.2.0


### PR DESCRIPTION
Upgrade `python-telegram-bot` to version 21.7 and adapt bot initialization to fix compatibility issues with Python 3.13.

The previous `python-telegram-bot` version 20.7 was incompatible with Python 3.13, leading to an `AttributeError` during `Updater` initialization. This PR updates the library to version 21.7 and refactors the bot's main function to use the `async/await` pattern required for proper operation with the newer library and Python 3.13.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b4a2cd3-dff4-47cb-82d1-e5643d21fff0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b4a2cd3-dff4-47cb-82d1-e5643d21fff0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

