### PR TITLE
Fix telegram bot attribute error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -540,7 +540,7 @@ async def main():
     app = (
         Application.builder()
         .token(BOT_TOKEN)
-        .get_updates_request_timeout(10.0)
+        .get_updates_read_timeout(10.0)
         .build()
     )
 

--- a/render_bot.py
+++ b/render_bot.py
@@ -95,7 +95,7 @@ async def run_telegram_bot():
                 .token(BOT_TOKEN)
                 .connect_timeout(20.0)
                 .read_timeout(20.0)
-                .get_updates_request_timeout(10.0)
+                .get_updates_read_timeout(10.0)
                 .build()
             )
 


### PR DESCRIPTION
Replace deprecated `get_updates_request_timeout` with `get_updates_read_timeout` to resolve `AttributeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c19c897-d232-4593-b5ed-934b0fadcf6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c19c897-d232-4593-b5ed-934b0fadcf6c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

