### PR TITLE
Check telegram bot port binding

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,14 +3,11 @@ services:
     name: telegram-business-bot
     env: python
     buildCommand: pip install -r requirements.txt
-    startCommand: python render_bot.py
+    startCommand: gunicorn --bind 0.0.0.0:$PORT flask_bot:app --timeout 120 --workers 1 --threads 2 --log-level info
     plan: free
     healthCheckPath: /health
     envVars:
       - key: BOT_TOKEN
         sync: false
-        # חובה! יש להוסיף את הטוקן של הבוט מ-BotFather בפאנל רנדר
       - key: PYTHON_VERSION
         value: 3.11.0
-      - key: PORT
-        generateValue: true


### PR DESCRIPTION
Configure Render to bind Flask app with Gunicorn to fix 'No open ports detected' deployment.

The previous setup with `python render_bot.py` and a custom `PORT` variable prevented Render from detecting an open port, causing deployment to hang. Switching to Gunicorn and using Render's default `$PORT` ensures the web service correctly exposes an accessible port.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fe0b653-099c-406c-819c-3b647d82889c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4fe0b653-099c-406c-819c-3b647d82889c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

