### PR TITLE
Fix gunicorn app module not found error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Main application entry point for Gunicorn
+This file serves as the WSGI entry point for the Flask application
+"""
+
+# Import the Flask app from flask_bot
+from flask_bot import app
+
+# Expose the app for Gunicorn
+application = app
+
+if __name__ == "__main__":
+    # For local development
+    import os
+    port = int(os.environ.get('PORT', 10000))
+    app.run(host='0.0.0.0', port=port, debug=False)

--- a/render.yaml
+++ b/render.yaml
@@ -11,3 +11,5 @@ services:
         sync: false
       - key: PYTHON_VERSION
         value: 3.11.0
+      - key: PYTHONPATH
+        value: /opt/render/project/src

--- a/start.sh
+++ b/start.sh
@@ -31,4 +31,4 @@ exec gunicorn \
     --max-requests 1000 \
     --max-requests-jitter 50 \
     --worker-class sync \
-    flask_bot:app
+    app:application

--- a/start_gunicorn.py
+++ b/start_gunicorn.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Gunicorn startup script with better error handling
+"""
+
+import os
+import sys
+import subprocess
+
+def main():
+    port = os.environ.get('PORT', '10000')
+    
+    print(f"Starting Telegram Bot Service...")
+    print(f"Port: {port}")
+    print(f"Workers: 1 (singleton mode)")
+    
+    # Try different module configurations
+    module_configs = [
+        "app:application",
+        "app:app",
+        "flask_bot:app",
+    ]
+    
+    gunicorn_cmd = [
+        "gunicorn",
+        "--bind", f"0.0.0.0:{port}",
+        "--workers", "1",
+        "--threads", "1",
+        "--timeout", "120",
+        "--log-level", "info",
+        "--access-logfile", "-",
+        "--error-logfile", "-",
+        "--preload",
+        "--max-requests", "1000",
+        "--max-requests-jitter", "50",
+        "--worker-class", "sync"
+    ]
+    
+    # Try each module configuration
+    for module_config in module_configs:
+        try:
+            print(f"Trying to start with module: {module_config}")
+            cmd = gunicorn_cmd + [module_config]
+            subprocess.run(cmd, check=True)
+            break  # If successful, exit
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to start with {module_config}: {e}")
+            if module_config == module_configs[-1]:
+                print("All module configurations failed!")
+                sys.exit(1)
+            continue
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fix `ModuleNotFoundError` for Gunicorn on Render by standardizing the application entry point and ensuring correct Python path configuration.

The `ModuleNotFoundError` occurred because Gunicorn could not locate the Flask application using the original `flask_bot:app` reference within the Render environment. This PR introduces a dedicated `app.py` as the Gunicorn entry point (`app:application`), updates the `start.sh` script accordingly, and explicitly sets the `PYTHONPATH` in `render.yaml` to ensure the project's source directory is correctly included for module discovery. An alternative `start_gunicorn.py` script is also provided for increased robustness in module loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-83258875-65d9-4188-b982-dd31fcf8ffd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83258875-65d9-4188-b982-dd31fcf8ffd8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

