### PR TITLE
Fix bot initialization errors

### DIFF
--- a/flask_bot.py
+++ b/flask_bot.py
@@ -108,7 +108,7 @@ def run_bot_async():
                 from telegram.ext import Application, CommandHandler, CallbackQueryHandler, MessageHandler, filters
                 from bot import (
                     start, button_handler, handle_text, handle_contact_process,
-                    admin_command, export_leads
+                    admin_command, export_leads, export_appointments
                 )
 
                 # Build application with proper configuration


### PR DESCRIPTION
Add missing `export_appointments` import to resolve bot startup `NameError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f32d265a-90e2-4357-b62b-dbdda6be48eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f32d265a-90e2-4357-b62b-dbdda6be48eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

