### PR TITLE
Remove "closed for now" from opening message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -143,7 +143,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         dm.save_data()
         await update.message.reply_text('🎉 הוגדרת כמנהל הבוט!')
     
-    status_prefix = '🟢 פתוח עכשיו - נענה מיד!' if is_business_open() else '🔴 סגור כרגע - נחזור בשעות הפעילות'
+    status_prefix = '🟢 פתוח עכשיו - נענה מיד!' if is_business_open() else ''
     await update.message.reply_text(
         f"{status_prefix}\n\n" + dm.data['settings']['welcome_message'],
         reply_markup=main_menu_keyboard()


### PR DESCRIPTION
Remove the "currently closed" status prefix from the opening message when the business is closed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d14560b-3956-413d-84cf-4a59751c62d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d14560b-3956-413d-84cf-4a59751c62d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

